### PR TITLE
fix(tests): Replace hardcoded array size with dynamic size

### DIFF
--- a/tests/unit/json-commands.test.mjs
+++ b/tests/unit/json-commands.test.mjs
@@ -765,14 +765,15 @@ describeForEachMode('JSON Commands - ValkeyJSON Compatibility', mode => {
 
       // Get array length
       const length = await client.jsonArrLen('large:doc', '$.data');
-      assert.strictEqual(length, 1000);
+      assert.strictEqual(length, arraySize);
 
-      // Get specific element
-      const element = await client.jsonGet('large:doc', '$.data[500]');
+      // Get specific element (use middle index)
+      const middleIndex = Math.floor(arraySize / 2);
+      const element = await client.jsonGet('large:doc', `$.data[${middleIndex}]`);
       assert.ok(element);
 
       const parsed = JSON.parse(element);
-      assert.strictEqual(parsed.id, 500);
+      assert.strictEqual(parsed.id, middleIndex);
     });
   });
 


### PR DESCRIPTION
This pull request updates the JSON array test in the `JSON Commands - ValkeyJSON Compatibility` suite to improve flexibility and accuracy by using the `arraySize` variable instead of hardcoded values. The test now dynamically calculates the middle index for element retrieval, ensuring it works regardless of array size.

Test improvements for flexibility and correctness:

* Replaced hardcoded array length check (`1000`) with `arraySize` for the assertion, allowing the test to adapt to different array sizes.
* Changed the retrieval and assertion of a specific array element from a fixed index (`500`) to the middle index (`Math.floor(arraySize / 2)`), making the test more robust for varying array sizes.