### PR TITLE
test(scripts): exclude cluster folder and JSON tests from standalone …

### DIFF
--- a/scripts/test-standalone.sh
+++ b/scripts/test-standalone.sh
@@ -47,8 +47,8 @@ export DISABLE_CLUSTER_TESTS="true"
 # Run tests
 echo -e "${YELLOW}Running standalone tests...${NC}"
 
-# Find all test files excluding cluster-specific ones
-TEST_FILES=$(find tests -name "*.test.mjs" | grep -v cluster | sort)
+# Find all test files excluding cluster folder and JSON tests
+TEST_FILES=$(find tests -name "*.test.mjs" -not -path "tests/cluster/*" | grep -v json | sort)
 
 # Run tests
 node --test \


### PR DESCRIPTION
This pull request updates the test script to further refine which test files are included when running standalone tests. The main change is to exclude both the `cluster` folder and any test files related to JSON from the test run.

Test selection improvements:

* Updated the `scripts/test-standalone.sh` script to exclude test files in the `cluster` folder and any test files related to JSON when collecting test files to run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined test discovery to exclude cluster-related and JSON-containing test files. This narrows the set of discovered tests, reducing irrelevant matches and improving test run predictability and speed without changing overall test execution flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->